### PR TITLE
Updated files to allow migration of Requirement based and Dynamic test suits

### DIFF
--- a/MTMCopyTool/ViewModels/OptionsViewModel.cs
+++ b/MTMCopyTool/ViewModels/OptionsViewModel.cs
@@ -18,6 +18,8 @@ namespace MTMCopyTool.ViewModels
                 new TestOutcomeFilter() {TestOutcome = TestOutcome.Failed, IsSelected = true},
                 new TestOutcomeFilter() {TestOutcome = TestOutcome.Blocked, IsSelected = true},
                 new TestOutcomeFilter() {TestOutcome = TestOutcome.Unspecified, IsSelected = true},
+                new TestOutcomeFilter() {TestOutcome = TestOutcome.NotApplicable, IsSelected = true},
+                new TestOutcomeFilter() {TestOutcome = TestOutcome.NotExecuted, IsSelected = true}
             };
         }
 


### PR DESCRIPTION
Hello Shairai,
I have made change to allow migration of Requirement based and Dynamic test suits. 

Earlier tool was supporting Static test case migration only so if any test plan consist of Dynamic or Requirement based test suit then tool was migrating static suit only ignoring other types. It was giving wrong impression that tool has migrated all the test suits/plan/cases under selected test plan. 

Now users need to expand test plan and explicitly to select which test plan/ test suit they want to migrate.
However if test plan or test suit contains only test cases then user can opt not to expand. 
![testplan](https://cloud.githubusercontent.com/assets/16759071/15578466/d7144284-2360-11e6-9cbe-2d9a1d1db827.png)

Review my changes and get back if additional information required.

Regards,
Shikhar Jain
